### PR TITLE
GHCR 조직 패키지 푸시 권한 문제 해결 및 테스트/버그픽스 브랜치 워크플로우 자동 실행 추가

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -76,7 +76,7 @@ jobs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.REGISTRY }}
-        username: ${{ github.actor }}
+        username: ${{ secrets.GHCR_USERNAME }}
         password: ${{ secrets.GHCR_TOKEN }}
         
     - name: 메타데이터 추출

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -77,7 +77,7 @@ jobs:
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.GHCR_TOKEN }}
         
     - name: 메타데이터 추출
       id: meta

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'fix/*' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ main, develop, 'fix/*' ]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## ⭐️ Issue Number
- #20 

## 🚩 Summary
- GHCR(GitHub Container Registry) 조직 패키지 푸시 시 권한 에러를 해결했습니다.
- 테스트/버그픽스 브랜치(fix/*)에서도 워크플로우가 자동 실행되도록 브랜치 패턴을 추가했습니다.
- Docker 레지스트리 로그인 시 GITHUB_TOKEN → GHCR_TOKEN(개인 Access Token) 시크릿으로 교체했습니다.

## 🛠️ Technical Concerns
- 워크플로우 트리거 조건:  
  - 기존 main, develop 뿐 아니라, fix/* 브랜치에도 push/pull_request 이벤트에서 자동 실행
- 시크릿 이름 변경:  
  - `${{ secrets.GITHUB_TOKEN }}` → `${{ secrets.GHCR_TOKEN }}`
  - GHCR_TOKEN에는 write:packages 권한이 있는 Personal Access Token 사용
- 메인 브랜치(main)가 아닌 경우에는 배포(deploy-development, deploy-production) job은 실행되지 않음

## 🙂 To Reviewer
- 패키지 푸시 권한/시크릿 교체 및 브랜치 패턴 추가 적용이 잘 되었는지 리뷰 부탁드립니다.
- 혹시 추가적으로 더 테스트해볼 케이스나 의견 있으면 코멘트 부탁드립니다!

## 📋 To Do
- [ ] main브랜치에서의 워크플로우 정상 동작 재확인
- [ ] 실제 운영 패키지 푸시 후 문제 없는지 검증
- [ ] 필요시 organization owner 계정에서 1회 push 테스트



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **Chores**
  * CI/CD 파이프라인이 'fix/*' 패턴의 브랜치에서도 자동으로 실행되도록 범위가 확장되었습니다.
  * Docker 레지스트리 인증에 사용되는 토큰이 `GITHUB_TOKEN`에서 `GHCR_TOKEN`으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->