### PR TITLE
docker-compose 네트워크 정의 추가 및 배포 환경 구성 오류 수정

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -36,3 +36,7 @@ services:
     networks:
       - ururu-network
     restart: unless-stopped
+
+networks:
+  ururu-network:
+    driver: bridge


### PR DESCRIPTION
## ⭐️ Issue Number
- #20 

## 🚩 Summary
- production 환경에서 docker-compose 실행 시 발생한 네트워크 정의 누락 에러를 해결했습니다.
- docker-compose.production.yml 하단에 ururu-network 네트워크 정의를 추가했습니다.
- 관련 Dockerfile, docker-compose.yml, docker-compose.development.yml, docker-compose.production.yml 전체를 점검하고, 서비스 정의 및 네트워크 설정의 일관성을 검증했습니다.

## 🛠️ Technical Concerns
- docker-compose.production.yml:
  - `fluent-bit` 서비스가 사용하는 `ururu-network` 네트워크 정의를 추가했습니다.
  - CI/CD 파이프라인에서 `docker compose config --quiet` 단계가 정상적으로 통과하도록 수정.
- Dockerfile:
  - 빌드 대상, 환경 변수 처리, 의존성 설치 및 실행 명령어 등 별다른 이상 없음.
- docker-compose.yml, docker-compose.development.yml:
  - 서비스 및 네트워크 정의 정상.
  - 별도의 네트워크 정의나 구성 오류 발견되지 않음.
- 전체적으로 services 및 networks 섹션의 오타/누락 등은 없는 것으로 확인.

## 🙂 To Reviewer
- 운영 환경에서의 docker-compose 배포 및 네트워크 구성이 정상 동작하는지 검토 부탁드립니다.
- 혹시 추가적으로 검증이 필요한 부분이나 개선점 있으면 의견 주시면 반영하겠습니다.

## 📋 To Do
- [ ] production 환경에서 docker-compose 정상 실행 검증
- [ ] develop, main 브랜치의 워크플로우 재테스트
- [ ] (필요시) README 또는 운영 가이드 업데이트

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker Compose 프로덕션 설정에 `ururu-network` 네트워크를 명시적으로 추가하여 네트워크 관리가 더욱 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->